### PR TITLE
patch: remove cred path for dummy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: <cluster-name>
@@ -87,7 +86,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: example-name
@@ -142,7 +140,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: <cluster-name>
@@ -176,7 +173,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
 ols_config:

--- a/examples/multi-provider/rcsconfig.yaml
+++ b/examples/multi-provider/rcsconfig.yaml
@@ -2,7 +2,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: first-provider-name

--- a/examples/rhdh-config-enabled/rcsconfig.yaml
+++ b/examples/rhdh-config-enabled/rcsconfig.yaml
@@ -2,7 +2,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
 ols_config:

--- a/examples/single-provider/rcsconfig.yaml
+++ b/examples/single-provider/rcsconfig.yaml
@@ -2,7 +2,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: my-cluster-name

--- a/templates/skeleton/rcsconfig.yaml
+++ b/templates/skeleton/rcsconfig.yaml
@@ -2,7 +2,6 @@ llm_providers:
   - name: dummy
     type: openai
     url: https://dummy.com
-    credentials_path: config/provider-keys/dummy
     models:
       - name: dummymodel
   - name: <cluster-name>


### PR DESCRIPTION
This PR removes the credential path from the dummy provider as RCS fails because it can't find it (as it doesn't exist and shouldn't). I forgot to include this in my original PR as the resources file I was testing with was git ignored and I only made the change there..