### PR TITLE
[RHDHPAI-818] add shared volume for feedback storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,17 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"
 ```
 
 **query_validation_method** section is recommended to be set as **llm** to enable question validation. If you want to turn off the validation, set to **disabled**
@@ -105,11 +111,17 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"
 ```
 
 For the purpose of this example I named my provider **example-name**, this name can be anything you want it to be. Keep note of it as it will be the provider name you pass when hitting RCS endpoints.
@@ -159,11 +171,17 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"
 ```
 
 **query_validation_method** section is recommended to be set as **llm** to enable question validation. If you want to turn off the validation, set this value to **disabled**. Or you can set **questionValidation** in RHDH lightspeed config.
@@ -189,11 +207,17 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"
 ```
 
 As for the `rcssecret.yaml` file, you are free to leave that unedited as it won't be used.

--- a/examples/multi-provider/rcsconfig.yaml
+++ b/examples/multi-provider/rcsconfig.yaml
@@ -24,8 +24,14 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"

--- a/examples/rhdh-config-enabled/rcsconfig.yaml
+++ b/examples/rhdh-config-enabled/rcsconfig.yaml
@@ -14,8 +14,14 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"

--- a/examples/single-provider/rcsconfig.yaml
+++ b/examples/single-provider/rcsconfig.yaml
@@ -19,8 +19,14 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"

--- a/templates/backstage/sidecar-setup.yaml
+++ b/templates/backstage/sidecar-setup.yaml
@@ -23,6 +23,8 @@ containers:
       - mountPath: /app-root/config/sed.edit.RHDH_CONFIG_FILENAME
         name: sed.edit.RHDH_CONFIG_NAME
         subPath: sed.edit.RHDH_CONFIG_FILENAME
+      - mountPath: /app-root/tmp/data/feedback
+        name: shared-data
 volumes:
   - name: rcsconfig
     configMap:
@@ -30,3 +32,5 @@ volumes:
   - name: provider-keys
     secret:
       secretName: provider-keys
+  - name: shared-data
+    emptyDir: {}

--- a/templates/skeleton/rcsconfig.yaml
+++ b/templates/skeleton/rcsconfig.yaml
@@ -19,8 +19,14 @@ ols_config:
   default_provider: dummy
   default_model: dummymodel
   query_validation_method: llm
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/app-root/tmp/data/feedback"
 dev_config:
   enable_dev_ui: false
   disable_auth: false
   disable_tls: true
   enable_system_prompt_override: true
+user_data_collector_config:
+  ingress_url: "https://example.ingress.com/upload"
+  user_agent: "example-agent"


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

- Update rcsconfig.yaml to add the `user_data_collection` and `user_data_collector_config` sections that enable the feedback handling and defines the local storage path
- Update sidecar-setup.yaml to add a newly created volume (created with emptydir) and mount it to the rcs sidecar

**Note:** By doing it this way when we eventually have the 3rd sidecar that road-core provides that handles the reading of data and pushing to S3 it will be able to read from the Volume. 

I believe for now (as in for the tech preview) we can get away with having everything in 1 Pod and communicating via ephemeral Volumes, however, we will eventually need to look into moving to persistent volumes if we want to completely eliminate the risk of data loss if the pod goes down.
 
### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

This change is part of https://issues.redhat.com/browse/RHDHPAI-818, still need to update the documentation on Google Drive before the issue is complete.

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:

Run the setup as normal and then you can hit the the `/feedback` endpoint. After that is done and it told you it created the feedback successfully you can navigate to the location in the filesystem and see the .json file.